### PR TITLE
Use dynamic port for test connections

### DIFF
--- a/server.js
+++ b/server.js
@@ -101,9 +101,10 @@ function broadcast() {
 setInterval(broadcast, 50);
 
 function start(port = PORT) {
-  return server.listen(port, () => {
+  server.listen(port, () => {
     console.log(`Server listening on ${port}`);
   });
+  return server;
 }
 
 if (require.main === module) {

--- a/tests/connect_test.js
+++ b/tests/connect_test.js
@@ -2,23 +2,26 @@ const { start } = require('../server');
 const net = require('net');
 const crypto = require('crypto');
 
-const server = start(8765);
+const server = start(0);
 
-const socket = net.createConnection(8765, 'localhost', () => {
-  const key = crypto.randomBytes(16).toString('base64');
-  const req =
-    'GET / HTTP/1.1\r\n' +
-    'Host: localhost\r\n' +
-    'Upgrade: websocket\r\n' +
-    'Connection: Upgrade\r\n' +
-    `Sec-WebSocket-Key: ${key}\r\n` +
-    'Sec-WebSocket-Version: 13\r\n' +
-    '\r\n';
-  socket.write(req);
-});
+server.on('listening', () => {
+  const port = server.address().port;
+  const socket = net.createConnection(port, 'localhost', () => {
+    const key = crypto.randomBytes(16).toString('base64');
+    const req =
+      'GET / HTTP/1.1\r\n' +
+      'Host: localhost\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Key: ${key}\r\n` +
+      'Sec-WebSocket-Version: 13\r\n' +
+      '\r\n';
+    socket.write(req);
+  });
 
-socket.once('data', data => {
-  console.log(data.toString().split('\r\n')[0]);
-  socket.destroy();
-  server.close();
+  socket.once('data', data => {
+    console.log(data.toString().split('\r\n')[0]);
+    socket.destroy();
+    server.close();
+  });
 });


### PR DESCRIPTION
## Summary
- update `start()` to always return the server instance
- bind connection tests to an OS-assigned port

## Testing
- `timeout 3 node tests/connect_test.js`

------
https://chatgpt.com/codex/tasks/task_e_68427a7fb69c8320875bc121f6823048